### PR TITLE
Add a bunch of ESLint rules

### DIFF
--- a/rules/errors.js
+++ b/rules/errors.js
@@ -4,10 +4,6 @@ module.exports = {
         // http://eslint.org/docs/rules/no-console
         'no-console': 'warn',
 
-        // disallow declaration of variables already declared in the outer scope
-        // http://eslint.org/docs/rules/no-shadow
-        'no-shadow': 'error',
-
         // disallow use of variables before they are defined
         // http://eslint.org/docs/rules/no-use-before-define
         'no-use-before-define': 'error'

--- a/rules/style.js
+++ b/rules/style.js
@@ -12,6 +12,15 @@ module.exports = {
         // http://eslint.org/docs/rules/comma-spacing
         'comma-spacing': 'error',
 
+        // if a variable is initialized or assigned the value this,
+        // the name of the variable must be "self"
+        // http://eslint.org/docs/rules/consistent-this
+        'consistent-this': ['error', 'self'],
+
+        // enforce the consistent use of either function expressions
+        // http://eslint.org/docs/rules/func-style
+        'func-style': 'error',
+
         // 4-space indentation
         // http://eslint.org/docs/rules/indent
         'indent': 'error',
@@ -28,6 +37,18 @@ module.exports = {
         // http://eslint.org/docs/rules/newline-after-var
         'newline-after-var': 'error',
 
+        // disallow empty lines over the specified maximum
+        // http://eslint.org/docs/rules/no-multiple-empty-lines
+        'no-multiple-empty-lines': ['error', {
+            max: 2,
+            maxEOF: 1,
+            maxBOF: 0
+        }],
+
+        // disallows the use of nested ternary expressions
+        // http://eslint.org/docs/rules/no-nested-ternary
+        'no-nested-ternary': 'error',
+
         // disallow whitespace before properties
         // http://eslint.org/docs/rules/no-whitespace-before-property
         'no-whitespace-before-property': 'error',
@@ -35,6 +56,15 @@ module.exports = {
         // disallow padding within curly braces of object literals
         // http://eslint.org/docs/rules/object-curly-spacing
         'object-curly-spacing': 'error',
+
+        // enforce `var` variables to be declared either together
+        // and `let` & `const` separately
+        // http://eslint.org/docs/rules/one-var
+        'one-var': ['error', {
+            'var': 'always',
+            'let': 'never',
+            'const': 'never'
+        }],
 
         // require a newline around variable declarations
         // http://eslint.org/docs/rules/one-var-declaration-per-line

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -2,6 +2,39 @@ module.exports = {
     'rules': {
         // disallow trailing commas
         // http://eslint.org/docs/rules/comma-dangle
-        'comma-dangle': 'error'
+        'comma-dangle': ['error', 'only-multiline'],
+
+        // require initialization in variable declarations
+        // http://eslint.org/docs/rules/init-declarations
+        'init-declarations': 'error',
+
+        // disallow `catch` clause parameters from shadowing variables in the
+        // outer scope
+        // http://eslint.org/docs/rules/no-catch-shadow
+        'no-catch-shadow': 'error',
+
+        // disallow specified global variables
+        // http://eslint.org/docs/rules/no-restricted-globals
+        'no-restricted-globals': ['error', 'event'],
+
+        // disallow declaration of variables already declared in the outer scope
+        // http://eslint.org/docs/rules/no-shadow
+        'no-shadow': 'error',
+
+        // disallow identifiers from shadowing restricted names
+        // http://eslint.org/docs/rules/no-shadow-restricted-names
+        'no-shadow-restricted-names': 'error',
+
+        // disallow initializing variables to `undefined`
+        // http://eslint.org/docs/rules/no-undef-init
+        'no-undef-init': 'error',
+
+        // disallow use of `undefined` variable
+        // http://eslint.org/docs/rules/no-undefined
+        'no-undefined': 'error',
+
+        // disallow the use of variables before they are defined
+        // http://eslint.org/docs/rules/no-use-before-define
+        'no-use-before-define': 'error'
     }
 };


### PR DESCRIPTION
Most of the rules are obvious ones that shouldn't have been happening anyway. Just not being enforced.
The significant ones are:
- Relaxing `comma-dangle` to allow for leaving dangling commas on multiple lines
- Restricting the use of `undefined` altogether
- Enforcing function expressions
